### PR TITLE
fix(bug): 'noImplicitUseStrict cannot be specified with option' error

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -8,6 +8,7 @@ const run = async (): Promise<void> => {
     .options({
       noImplicitAny: { type: 'boolean', default: true },
       noImplicitThis: { type: 'boolean', default: true },
+      noImplicitUseStrict: { type: 'boolean', default: false },
       alwaysStrict: { type: 'boolean', default: true },
       strictBindCallApply: { type: 'boolean', default: true },
       strictNullChecks: { type: 'boolean', default: true },


### PR DESCRIPTION
otherwise, if the project's tsconfig.json has 'noImplicitUseStrict ' option ts-strictify will just say there is no error because it does not check such errors.

It took me a while to understand what's happening. Only after added some logs I got an idea. Before, I thought that the tool is not working.