### PR TITLE
Log the number of errors found

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,7 @@ const run = async (): Promise<void> => {
   })
 
   if (result.errors) {
+    console.log(`💥  ${result.errors} errors found`);
     process.exit(1)
   } else {
     console.log(`🎉  ${chalk.green('All files passed')}`)


### PR DESCRIPTION
The number of errors might be helpful to make a decision if to disable typecheck in build or just go ahead and fix them.