### PR TITLE
fix(tsc): prefer local binary

### DIFF
--- a/src/lib/typescript.ts
+++ b/src/lib/typescript.ts
@@ -19,7 +19,7 @@ export const compile = async (options: TypeScriptOptions): Promise<string[]> => 
 
   let tscOutput: string[] = []
   try {
-    await execa('tsc', args, { all: true })
+    await execa('tsc', args, { all: true, preferLocal: true })
   } catch (error) {
     const { all } = error
     tscOutput = (all as string).split('\n')


### PR DESCRIPTION
Since a version of `typescript` will often already be a dependency in a project using `ts-strictify`, it makes sense to prefer the local binary.

This will also fix when `typescript` hoisted in Lerna as  mentioned in #4 