### PR TITLE
feat: noUncheckedIndexedAccess support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options:
   --strictNullChecks                              [boolean] [default: true]
   --strictFunctionTypes                           [boolean] [default: true]
   --strictPropertyInitialization                  [boolean] [default: true]
+  --noUncheckedIndexedAccess                      [boolean] [default: true]
   --noEmit                                        [boolean] [default: true]
   --targetBranch                               [string] [default: "master"]
   --commitedFiles                                 [boolean] [default: true]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "yargs": "^15.3.0"
   },
   "peerDependencies": {
-    "typescript": "3.x"
+    "typescript": ">=3"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",
@@ -62,7 +62,7 @@
     "pretty-quick": "2.0.1",
     "semantic-release": "17.0.4",
     "tmp-promise": "2.0.2",
-    "typescript": "3.7.5"
+    "typescript": "4.1.2"
   },
   "husky": {
     "hooks": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ const run = async (): Promise<void> => {
       strictNullChecks: { type: 'boolean', default: true },
       strictFunctionTypes: { type: 'boolean', default: true },
       strictPropertyInitialization: { type: 'boolean', default: true },
+      noUncheckedIndexedAccess: { type: 'boolean', default: true },
       noEmit: { type: 'boolean', default: true },
       targetBranch: { type: 'string', default: 'master' },
       commitedFiles: { type: 'boolean', default: true },
@@ -36,6 +37,7 @@ const run = async (): Promise<void> => {
     'strictNullChecks',
     'strictFunctionTypes',
     'strictPropertyInitialization',
+    'noUncheckedIndexedAccess',
     'noEmit',
   ])
 

--- a/src/lib/typescript.ts
+++ b/src/lib/typescript.ts
@@ -9,6 +9,7 @@ export interface TypeScriptOptions {
   strictNullChecks: boolean
   strictFunctionTypes: boolean
   strictPropertyInitialization: boolean
+  noUncheckedIndexedAccess: boolean
   noEmit: boolean
 }
 

--- a/tests/help/help-output-mother.ts
+++ b/tests/help/help-output-mother.ts
@@ -349,41 +349,111 @@ Examples: tsc hello.ts
           tsc --build tsconfig.json
 
 Options:
- -h, --help                                         Print this message.
- -w, --watch                                        Watch input files.
- --pretty                                           Stylize errors and messages using color and context (experimental).
  --all                                              Show all compiler options.
- -v, --version                                      Print the compiler's version.
- --init                                             Initializes a TypeScript project and creates a tsconfig.json file.
- -p FILE OR DIRECTORY, --project FILE OR DIRECTORY  Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
+ --allowJs                                          Allow javascript files to be compiled.
+ --allowSyntheticDefaultImports                     Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
+ --allowUmdGlobalAccess                             Allow accessing UMD globals from modules.
+ --allowUnreachableCode                             Do not report errors on unreachable code.
+ --allowUnusedLabels                                Do not report errors on unused labels.
+ --alwaysStrict                                     Parse in strict mode and emit "use strict" for each source file.
+ --assumeChangesOnlyAffectDirectDependencies        Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it.
+ --baseUrl                                          Base directory to resolve non-absolute module names.
  -b, --build                                        Build one or more projects and their dependencies, if out of date
- -t VERSION, --target VERSION                       Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'.
- -m KIND, --module KIND                             Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'.
+ --charset                                          The character set of the input files.
+ --checkJs                                          Report errors in .js files.
+ --composite                                        Enable project compilation
+ -d, --declaration                                  Generates corresponding '.d.ts' file.
+ --declarationDir DIRECTORY                         Output directory for generated declaration files.
+ --declarationMap                                   Generates a sourcemap for each corresponding '.d.ts' file.
+ --diagnostics                                      Show diagnostic information.
+ --disableReferencedProjectLoad                     Disable loading referenced projects.
+ --disableSizeLimit                                 Disable size limitations on JavaScript projects.
+ --disableSolutionSearching                         Disable solution searching for this project.
+ --disableSourceOfProjectReferenceRedirect          Disable use of source files instead of declaration files from referenced projects.
+ --downlevelIteration                               Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'.
+ --emitBOM                                          Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.
+ --emitDeclarationOnly                              Only emit '.d.ts' declaration files.
+ --emitDecoratorMetadata                            Enables experimental support for emitting type metadata for decorators.
+ --esModuleInterop                                  Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'.
+ --experimentalDecorators                           Enables experimental support for ES7 decorators.
+ --extendedDiagnostics                              Show verbose diagnostic information.
+ --forceConsistentCasingInFileNames                 Disallow inconsistently-cased references to the same file.
+ --generateCpuProfile FILE OR DIRECTORY             Generates a CPU profile.
+ --generateTrace DIRECTORY                          Generates an event trace and a list of types.
+ -h, --help                                         Print this message.
+ --importHelpers                                    Import emit helpers from 'tslib'.
+ --importsNotUsedAsValues                           Specify emit/checking behavior for imports that are only used for types
+ -i, --incremental                                  Enable incremental compilation
+ --init                                             Initializes a TypeScript project and creates a tsconfig.json file.
+ --inlineSourceMap                                  Emit a single file with source maps instead of having a separate file.
+ --inlineSources                                    Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set.
+ --isolatedModules                                  Transpile each file as a separate module (similar to 'ts.transpileModule').
+ --jsx KIND                                         Specify JSX code generation: 'preserve', 'react-native', or 'react'.
+ --jsxFactory                                       Specify the JSX factory function to use when targeting 'react' JSX emit, e.g. 'React.createElement' or 'h'.
+ --jsxFragmentFactory                               Specify the JSX fragment factory function to use when targeting 'react' JSX emit with 'jsxFactory' compiler option is specified, e.g. 'Fragment'.
+ --jsxImportSource                                  Specify the module specifier to be used to import the \`jsx\` and \`jsxs\` factory functions from. eg, react
+ --keyofStringsOnly                                 Resolve 'keyof' to string valued property names only (no numbers or symbols).
  --lib                                              Specify library files to be included in the compilation.
                                                       'es5' 'es6' 'es2015' 'es7' 'es2016' 'es2017' 'es2018' 'es2019' 'es2020' 'esnext' 'dom' 'dom.iterable' 'webworker' 'webworker.importscripts' 'webworker.iterable' 'scripthost' 'es2015.core' 'es2015.collection' 'es2015.generator' 'es2015.iterable' 'es2015.promise' 'es2015.proxy' 'es2015.reflect' 'es2015.symbol' 'es2015.symbol.wellknown' 'es2016.array.include' 'es2017.object' 'es2017.sharedmemory' 'es2017.string' 'es2017.intl' 'es2017.typedarrays' 'es2018.asyncgenerator' 'es2018.asynciterable' 'es2018.intl' 'es2018.promise' 'es2018.regexp' 'es2019.array' 'es2019.object' 'es2019.string' 'es2019.symbol' 'es2020.bigint' 'es2020.promise' 'es2020.sharedmemory' 'es2020.string' 'es2020.symbol.wellknown' 'es2020.intl' 'esnext.array' 'esnext.symbol' 'esnext.asynciterable' 'esnext.intl' 'esnext.bigint' 'esnext.string' 'esnext.promise' 'esnext.weakref' 
- --allowJs                                          Allow javascript files to be compiled.
- --jsx KIND                                         Specify JSX code generation: 'preserve', 'react-native', or 'react'.
- -d, --declaration                                  Generates corresponding '.d.ts' file.
- --declarationMap                                   Generates a sourcemap for each corresponding '.d.ts' file.
- --sourceMap                                        Generates corresponding '.map' file.
- --outFile FILE                                     Concatenate and emit output to single file.
- --outDir DIRECTORY                                 Redirect output structure to the directory.
- --removeComments                                   Do not emit comments to output.
+ --listEmittedFiles                                 Print names of generated files part of the compilation.
+ --listFiles                                        Print names of files part of the compilation.
+ --listFilesOnly                                    Print names of files that are part of the compilation and then stop processing.
+ --locale                                           The locale used when displaying messages to the user (e.g. 'en-us')
+ --mapRoot LOCATION                                 Specify the location where debugger should locate map files instead of generated locations.
+ --maxNodeModuleJsDepth                             The maximum dependency depth to search under node_modules and load JavaScript files.
+ -m KIND, --module KIND                             Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'.
+ --moduleResolution STRATEGY                        Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6).
+ --newLine NEWLINE                                  Specify the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).
  --noEmit                                           Do not emit outputs.
- --strict                                           Enable all strict type-checking options.
+ --noEmitHelpers                                    Do not generate custom helper functions like '__extends' in compiled output.
+ --noEmitOnError                                    Do not emit outputs if any errors were reported.
+ --noErrorTruncation                                Do not truncate error messages.
+ --noFallthroughCasesInSwitch                       Report errors for fallthrough cases in switch statement.
  --noImplicitAny                                    Raise error on expressions and declarations with an implied 'any' type.
- --strictNullChecks                                 Enable strict null checks.
- --strictFunctionTypes                              Enable strict checking of function types.
- --strictBindCallApply                              Enable strict 'bind', 'call', and 'apply' methods on functions.
- --strictPropertyInitialization                     Enable strict checking of property initialization in classes.
+ --noImplicitReturns                                Report error when not all code paths in function return a value.
  --noImplicitThis                                   Raise error on 'this' expressions with an implied 'any' type.
- --alwaysStrict                                     Parse in strict mode and emit "use strict" for each source file.
+ --noImplicitUseStrict                              Do not emit 'use strict' directives in module output.
+ --noLib                                            Do not include the default library file (lib.d.ts).
+ --noResolve                                        Do not add triple-slash references or imported modules to the list of compiled files.
+ --noStrictGenericChecks                            Disable strict checking of generic signatures in function types.
+ --noUncheckedIndexedAccess                         Include 'undefined' in index signature results
  --noUnusedLocals                                   Report errors on unused locals.
  --noUnusedParameters                               Report errors on unused parameters.
- --noImplicitReturns                                Report error when not all code paths in function return a value.
- --noFallthroughCasesInSwitch                       Report errors for fallthrough cases in switch statement.
+ --out FILE                                         [Deprecated] Use '--outFile' instead. Concatenate and emit output to single file
+ --outDir DIRECTORY                                 Redirect output structure to the directory.
+ --outFile FILE                                     Concatenate and emit output to single file.
+ --paths                                            A series of entries which re-map imports to lookup locations relative to the 'baseUrl'.
+ --plugins                                          List of language service plugins.
+ --preserveConstEnums                               Do not erase const enum declarations in generated code.
+ --preserveSymlinks                                 Do not resolve the real path of symlinks.
+ --preserveWatchOutput                              Whether to keep outdated console output in watch mode instead of clearing the screen.
+ --pretty                                           Stylize errors and messages using color and context (experimental).
+ -p FILE OR DIRECTORY, --project FILE OR DIRECTORY  Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
+ --reactNamespace                                   [Deprecated] Use '--jsxFactory' instead. Specify the object invoked for createElement when targeting 'react' JSX emit
+ --removeComments                                   Do not emit comments to output.
+ --resolveJsonModule                                Include modules imported with '.json' extension
+ --rootDir LOCATION                                 Specify the root directory of input files. Use to control the output directory structure with --outDir.
+ --rootDirs                                         List of root folders whose combined content represents the structure of the project at runtime.
+ --showConfig                                       Print the final configuration instead of building.
+ --skipDefaultLibCheck                              [Deprecated] Use '--skipLibCheck' instead. Skip type checking of default library declaration files.
+ --skipLibCheck                                     Skip type checking of declaration files.
+ --sourceMap                                        Generates corresponding '.map' file.
+ --sourceRoot LOCATION                              Specify the location where debugger should locate TypeScript files instead of source locations.
+ --strict                                           Enable all strict type-checking options.
+ --strictBindCallApply                              Enable strict 'bind', 'call', and 'apply' methods on functions.
+ --strictFunctionTypes                              Enable strict checking of function types.
+ --strictNullChecks                                 Enable strict null checks.
+ --strictPropertyInitialization                     Enable strict checking of property initialization in classes.
+ --stripInternal                                    Do not emit declarations for code that has an '@internal' annotation.
+ --suppressExcessPropertyErrors                     Suppress excess property checks for object literals.
+ --suppressImplicitAnyIndexErrors                   Suppress noImplicitAny errors for indexing objects lacking index signatures.
+ -t VERSION, --target VERSION                       Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'.
+ --traceResolution                                  Enable tracing of the name resolution process.
+ --tsBuildInfoFile FILE                             Specify file to store incremental compilation information
+ --typeRoots                                        List of folders to include type definitions from.
  --types                                            Type declaration files to be included in compilation.
- --esModuleInterop                                  Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'.
- @<file>                                            Insert command line options and files from a file.
-✨  Done in 0.23s.`,
+ --useDefineForClassFields                          Emit class fields with Define instead of Set.
+ -v, --version                                      Print the compiler's version.
+ -w, --watch                                        Watch input files.
+ @<file>                                            Insert command line options and files from a file.`,
 }

--- a/tests/help/help-output-mother.ts
+++ b/tests/help/help-output-mother.ts
@@ -7,6 +7,7 @@ export const TestedVersions = [
   '2.7.1', // looks like there never was a 2.7.0
   '3.0.1', // looks like there never was a 3.0.1
   '3.2.1', // looks like there never was a 3.2.0
+  '4.1.2', // looks like there never was a 4.1.0
 ] as const
 export type TestedTscVersion = typeof TestedVersions[number]
 
@@ -339,4 +340,50 @@ Options:
  --esModuleInterop                                  Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'.
  @<file>                                            Insert command line options and files from a file.
 ✨  Done in 0.51s.`,
+  '4.1.2': `Version 4.1.2
+Syntax:   tsc [options] [file...]
+
+Examples: tsc hello.ts
+          tsc --outFile file.js file.ts
+          tsc @args.txt
+          tsc --build tsconfig.json
+
+Options:
+ -h, --help                                         Print this message.
+ -w, --watch                                        Watch input files.
+ --pretty                                           Stylize errors and messages using color and context (experimental).
+ --all                                              Show all compiler options.
+ -v, --version                                      Print the compiler's version.
+ --init                                             Initializes a TypeScript project and creates a tsconfig.json file.
+ -p FILE OR DIRECTORY, --project FILE OR DIRECTORY  Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
+ -b, --build                                        Build one or more projects and their dependencies, if out of date
+ -t VERSION, --target VERSION                       Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'.
+ -m KIND, --module KIND                             Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'.
+ --lib                                              Specify library files to be included in the compilation.
+                                                      'es5' 'es6' 'es2015' 'es7' 'es2016' 'es2017' 'es2018' 'es2019' 'es2020' 'esnext' 'dom' 'dom.iterable' 'webworker' 'webworker.importscripts' 'webworker.iterable' 'scripthost' 'es2015.core' 'es2015.collection' 'es2015.generator' 'es2015.iterable' 'es2015.promise' 'es2015.proxy' 'es2015.reflect' 'es2015.symbol' 'es2015.symbol.wellknown' 'es2016.array.include' 'es2017.object' 'es2017.sharedmemory' 'es2017.string' 'es2017.intl' 'es2017.typedarrays' 'es2018.asyncgenerator' 'es2018.asynciterable' 'es2018.intl' 'es2018.promise' 'es2018.regexp' 'es2019.array' 'es2019.object' 'es2019.string' 'es2019.symbol' 'es2020.bigint' 'es2020.promise' 'es2020.sharedmemory' 'es2020.string' 'es2020.symbol.wellknown' 'es2020.intl' 'esnext.array' 'esnext.symbol' 'esnext.asynciterable' 'esnext.intl' 'esnext.bigint' 'esnext.string' 'esnext.promise' 'esnext.weakref' 
+ --allowJs                                          Allow javascript files to be compiled.
+ --jsx KIND                                         Specify JSX code generation: 'preserve', 'react-native', or 'react'.
+ -d, --declaration                                  Generates corresponding '.d.ts' file.
+ --declarationMap                                   Generates a sourcemap for each corresponding '.d.ts' file.
+ --sourceMap                                        Generates corresponding '.map' file.
+ --outFile FILE                                     Concatenate and emit output to single file.
+ --outDir DIRECTORY                                 Redirect output structure to the directory.
+ --removeComments                                   Do not emit comments to output.
+ --noEmit                                           Do not emit outputs.
+ --strict                                           Enable all strict type-checking options.
+ --noImplicitAny                                    Raise error on expressions and declarations with an implied 'any' type.
+ --strictNullChecks                                 Enable strict null checks.
+ --strictFunctionTypes                              Enable strict checking of function types.
+ --strictBindCallApply                              Enable strict 'bind', 'call', and 'apply' methods on functions.
+ --strictPropertyInitialization                     Enable strict checking of property initialization in classes.
+ --noImplicitThis                                   Raise error on 'this' expressions with an implied 'any' type.
+ --alwaysStrict                                     Parse in strict mode and emit "use strict" for each source file.
+ --noUnusedLocals                                   Report errors on unused locals.
+ --noUnusedParameters                               Report errors on unused parameters.
+ --noImplicitReturns                                Report error when not all code paths in function return a value.
+ --noFallthroughCasesInSwitch                       Report errors for fallthrough cases in switch statement.
+ --types                                            Type declaration files to be included in compilation.
+ --esModuleInterop                                  Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'.
+ @<file>                                            Insert command line options and files from a file.
+✨  Done in 0.23s.`,
 }

--- a/tests/supported-options.spec.ts
+++ b/tests/supported-options.spec.ts
@@ -43,3 +43,7 @@ test('support for --strictFunctionTypes', () => {
 test('support for --strictBindCallApply', () => {
   expectToBeSupportedSince('3.2.1', 'strictBindCallApply')
 })
+
+test('support for --noUncheckedIndexedAccess', () => {
+  expectToBeSupportedSince('4.1.2', 'noUncheckedIndexedAccess')
+})

--- a/tests/ts-strictify.spec.ts
+++ b/tests/ts-strictify.spec.ts
@@ -2,6 +2,7 @@ import simpleGit from 'simple-git/promise'
 import tmp from 'tmp-promise'
 import { TypeScriptOptions } from '../src/lib/typescript'
 import { GitOptions } from '../src/lib/git'
+import fs from 'fs'
 
 import execa from 'execa'
 import { join } from 'path'
@@ -13,6 +14,9 @@ const runTsStrictifyInPath = async (
 ): Promise<string> => {
   const cwd = process.cwd()
   const tsStrictify = join(cwd, 'dist/cli.js')
+  if (!fs.existsSync(tsStrictify)) {
+    throw new Error('You must build ts-strictify with "yarn build" before running tests')
+  }
 
   const args = Object.entries(options)
     .map(([key, value]) => [key.replace(/^/, '--'), value])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,7 +2686,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3976,7 +3976,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -5178,11 +5178,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -5191,32 +5186,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -5257,11 +5230,6 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -8105,10 +8073,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 uglify-js@^3.1.4:
   version "3.8.0"


### PR DESCRIPTION
Adds support for `noUncheckedIndexedAccess` flag, an even stricter flag.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#no-unchecked-indexed-access

**Update:** On issue https://github.com/microsoft/TypeScript/issues/42659 the TS team instructed me to use `tsc --help --all` flag, which solved the issue.

---

Old comment, preserved for posterity

_This change does not actually work, as this flag appears to not work when running `tsc`, only with inside `tsconfig.json`._

_I created an issue on Typescript: https://github.com/microsoft/TypeScript/issues/42659_